### PR TITLE
Unify return type of filesytem create method.

### DIFF
--- a/src/ftp/FtpFileSystem.ts
+++ b/src/ftp/FtpFileSystem.ts
@@ -25,12 +25,12 @@ export default class FtpFileSystem implements FileSystem<FtpFileInfo> {
     connectionOptions?: FtpClient.Options;
   }): Promise<FtpFileSystem> {
     const c = new FtpClient();
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       c.on('ready', () => {
         resolve(new FtpFileSystem(c));
       });
       c.once('error', (err: Error) => {
-        throw err;
+        reject(err);
       });
       c.connect({
         host,

--- a/src/ftp/FtpFileSystem.ts
+++ b/src/ftp/FtpFileSystem.ts
@@ -23,14 +23,14 @@ export default class FtpFileSystem implements FileSystem<FtpFileInfo> {
     user: string;
     password: string;
     connectionOptions?: FtpClient.Options;
-  }): Promise<FtpFileSystem | Error> {
+  }): Promise<FtpFileSystem> {
     const c = new FtpClient();
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       c.on('ready', () => {
         resolve(new FtpFileSystem(c));
       });
       c.once('error', (err: Error) => {
-        reject(err);
+        throw err;
       });
       c.connect({
         host,


### PR DESCRIPTION
All create methods of the different Filesystems return an instance of itself and throw an error if necessary.